### PR TITLE
Accept custom raf function

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Wrap a `render` function that is called on every `raf` tick. If no new state is
 available, it will not tick. Passes the last version of the state on every tick.
 
 Optionally, provide an implementation of `requestAnimationFrame` via the
-optional `raf` parameter (for example, the one provided by the [raf
+`raf` parameter (for example, the one provided by the [raf
 package](https://www.npmjs.com/package/raf)).  If omitted, `raf` defaults to
 `window.requestAnimationFrame`.
 

--- a/README.md
+++ b/README.md
@@ -26,11 +26,16 @@ function updateState (state) {
 ```
 
 ## API
-### frame = nanoraf(render)
+### frame = nanoraf(render, raf?)
 Wrap a `render` function that is called on every `raf` tick. If no new state is
 available, it will not tick. Passes the last version of the state on every tick.
 
-### frame(state)
+Optionally, provide an implementation of `requestAnimationFrame` via the
+optional `raf` parameter (for example, the one provided by the [raf
+package](https://www.npmjs.com/package/raf)).  If omitted, `raf` defaults to
+`window.requestAnimationFrame`.
+
+### frame(state, prevState)
 Pass new state into the render function, to be called on a new tick.
 
 ## Installation

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const assert = require('assert')
 module.exports = nanoraf
 
 // Only call RAF when needed
-// fn -> fn
+// (fn, fn?) -> fn
 function nanoraf (render, raf) {
   assert.equal(typeof render, 'function', 'nanoraf: render should be a function')
   assert.ok(typeof raf === 'function' || typeof raf === 'undefined', 'nanoraf: raf should be a function or undefined')

--- a/index.js
+++ b/index.js
@@ -5,8 +5,11 @@ module.exports = nanoraf
 
 // Only call RAF when needed
 // fn -> fn
-function nanoraf (render) {
+function nanoraf (render, raf) {
   assert.equal(typeof render, 'function', 'nanoraf: render should be a function')
+  assert.ok(typeof raf === 'function' || typeof raf === 'undefined', 'nanoraf: raf should be a function or undefined')
+
+  if (!raf) { raf = window.requestAnimationFrame }
 
   var inRenderingTransaction = false
   var redrawScheduled = false
@@ -23,7 +26,7 @@ function nanoraf (render) {
     if (currentState === null && !redrawScheduled) {
       redrawScheduled = true
 
-      window.requestAnimationFrame(function redraw () {
+      raf(function redraw () {
         redrawScheduled = false
         if (!currentState) return
 

--- a/test.js
+++ b/test.js
@@ -1,7 +1,54 @@
 const test = require('tape')
+const window = require('global/window')
 const nanoraf = require('./')
 
 test('should assert input types', function (t) {
   t.plan(1)
   t.throws(nanoraf)
 })
+
+test('should default to window.requestAnimationFrame', function (t) {
+  t.plan(2)
+  const currentState = { status: 'currentState' }
+  const previousState = { status: 'previousState' }
+  window.requestAnimationFrame = function (fn) { setImmediate(fn) }
+  const render = function (curr, prev) {
+    t.same(curr, currentState)
+    t.same(prev, previousState)
+  }
+  const frame = nanoraf(render)
+  frame(currentState, previousState)
+})
+
+test('should use custom raf if provided', function (t) {
+  t.plan(2)
+  const currentState = { status: 'currentState' }
+  const previousState = { status: 'previousState' }
+  window.requestAnimationFrame = function (fn) { t.fail() }
+  const render = function (curr, prev) {
+    t.same(curr, currentState)
+    t.same(prev, previousState)
+  }
+  const frame = nanoraf(render, function (fn) { setImmediate(fn) })
+  frame(currentState, previousState)
+})
+
+test('should call render with newest "current" state and oldest "previous" state', function (t) {
+  t.plan(2)
+  const states = [
+    {count: 0},
+    {count: 1},
+    {count: 2}
+  ]
+
+  window.requestAnimationFrame = function (fn) { setImmediate(fn) }
+  const render = function (curr, prev) {
+    t.same(curr, states[2])
+    t.same(prev, states[0])
+  }
+
+  const frame = nanoraf(render)
+  frame(states[1], states[0])
+  frame(states[2], states[1])
+})
+


### PR DESCRIPTION
- Adds an optional second parameter for a custom raf function, thus allowing for a "polyfill" strategy that doesn't involve touching `window`.
- Also adds a regression test for correct state / previous state semantics (because I was already in `test.js`, so why not? :) )
