### PR TITLE
Use proper format for assert() function call

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ function nanoraf (render, raf) {
   return function frame (state, prev) {
     assert.equal(typeof state, 'object', 'nanoraf: state should be an object')
     assert.equal(typeof prev, 'object', 'nanoraf: prev should be an object')
-    assert.ifError(inRenderingTransaction, 'nanoraf: infinite loop detected')
+    assert.equal(inRenderingTransaction, false, 'nanoraf: infinite loop detected')
 
     // request a redraw for next frame
     if (currentState === null && !redrawScheduled) {


### PR DESCRIPTION
`assert.ifError(inRenderingTransaction, 'nanoraf: infinite loop detected')` is not a valid `assert` call.

As a result, when run through `unassertify`, the statement isn’t removed. (Also, it probably isn’t actually working properly.)

I replaced it with `assert.equal(inRenderingTransaction, false, 'nanoraf: infinite loop detected')` which seems closer to the actual purpose of the statement: to verify that the value of `inRenderingTransaction` is `false`, to avoid an infinite loop. `npm run test` comes back happy.

See [this issue comment in `choo`](https://github.com/yoshuawuyts/choo/issues/171#issuecomment-232696953) for the discovery of this issue.
